### PR TITLE
46 use case 3 register new user tests

### DIFF
--- a/src/main/java/uc/user/register/URegisterResponseModel.java
+++ b/src/main/java/uc/user/register/URegisterResponseModel.java
@@ -19,6 +19,14 @@ public class URegisterResponseModel {
         this.timestamp = timestamp;
     }
 
+    /** Get the User entity
+     *
+     * @return returns the User entity related to the user being registered
+     */
+    public User getUser() {
+        return user;
+    }
+
     /** Get the login of the User
      *
      * @return returns the login of the User

--- a/src/test/java/uc/user/register/UserRegisterInteractorTest.java
+++ b/src/test/java/uc/user/register/UserRegisterInteractorTest.java
@@ -46,7 +46,7 @@ public class UserRegisterInteractorTest {
                 // Check if the email matches
                 assertEquals(user.getUser().getEmail(), "email@email.com");
                 // Check if the userId is created and is of length 9
-                assertEquals((user.getUser().getUserId()).length(), 9);
+                assertEquals((user.getUser().getId()).length(), 8);
                 // Check if the timestamp is not empty
                 assertNotNull(user.timestamp);
 

--- a/src/test/java/uc/user/register/UserRegisterInteractorTest.java
+++ b/src/test/java/uc/user/register/UserRegisterInteractorTest.java
@@ -69,6 +69,50 @@ public class UserRegisterInteractorTest {
 
         interactor.registerUser(requestModel);
     }
+    @Test
+    public void userExists(){
+        // Asserting if the register was a fail because the user exists.
+        URegisterDsGateway userDsGateway = new URegisterDsGateway() {
+            @Override
+            public boolean checkIfUserExistsByEmail(String email) {
+                return true;
+            }
+
+            @Override
+            public boolean saveNewUserInfo(URegisterDsRequestModel requestModel) {
+                return false;
+            }
+
+            @Override
+            public boolean checkIfUserExists(String userId) {
+                return false;
+            }
+        };
+
+        URegisterOutputBoundary userOutputBoundary = new URegisterOutputBoundary() {
+            @Override
+            public URegisterResponseModel prepareSuccessView(URegisterResponseModel user) {
+                return null;
+            }
+
+            @Override
+            public URegisterResponseModel prepareFailView(String error) {
+                assertTrue(userDsGateway.checkIfUserExistsByEmail("email@email.com"));
+                return null;
+            }
+        };
+
+        UserFactory userFactory = new UserFactory();
+
+        UserRegisterInteractor interactor = new UserRegisterInteractor(userDsGateway,
+                userOutputBoundary, userFactory);
+
+        URegisterRequestModel requestModel = new URegisterRequestModel("John", "Doe",
+                "email@email.com", "password", "password");
+
+        interactor.registerUser(requestModel);
+    }
+
 
 
 

--- a/src/test/java/uc/user/register/UserRegisterInteractorTest.java
+++ b/src/test/java/uc/user/register/UserRegisterInteractorTest.java
@@ -1,0 +1,77 @@
+package uc.user.register;
+
+import entities.User;
+import entities.UserFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class UserRegisterInteractorTest {
+
+    @Test
+    public void registerSuccess() {
+
+        URegisterDsGateway userDsGateway = new URegisterDsGateway() {
+            /* Initializing a URegisterDsGateway that states that a user does not exist in the db
+            and that the user info was saved.
+            *
+            * */
+
+            @Override
+            public boolean checkIfUserExistsByEmail(String email) {
+                return false;
+            }
+
+            @Override
+            public boolean saveNewUserInfo(URegisterDsRequestModel requestModel) {
+                return true;
+            }
+
+            @Override
+            public boolean checkIfUserExists(String userId) {
+                return false;
+            }
+        };
+
+        URegisterOutputBoundary userOutputBoundary = new URegisterOutputBoundary() {
+            // Asserting if the register was a success.
+
+            @Override
+            public URegisterResponseModel prepareSuccessView(URegisterResponseModel user) {
+                // Check if the user's first name matches
+                assertEquals(user.getUser().getFirstName(), "John");
+                // Check if the user's last name matches
+                assertEquals(user.getUser().getLastName(), "Doe");
+                // Check if the email matches
+                assertEquals(user.getUser().getEmail(), "email@email.com");
+                // Check if the userId is created and is of length 9
+                assertEquals((user.getUser().getUserId()).length(), 9);
+                // Check if the timestamp is not empty
+                assertNotNull(user.timestamp);
+
+                return null;
+            };
+
+            @Override
+            public URegisterResponseModel prepareFailView(String error) {
+                return null;
+            }
+        };
+
+        UserFactory userFactory = new UserFactory();
+
+        UserRegisterInteractor interactor = new UserRegisterInteractor(userDsGateway,
+                userOutputBoundary, userFactory);
+
+        URegisterRequestModel requestModel = new URegisterRequestModel("John", "Doe",
+                "email@email.com", "password", "password");
+
+        interactor.registerUser(requestModel);
+    }
+
+
+
+
+
+}

--- a/src/test/java/uc/user/register/UserRegisterInteractorTest.java
+++ b/src/test/java/uc/user/register/UserRegisterInteractorTest.java
@@ -11,7 +11,10 @@ public class UserRegisterInteractorTest {
 
     @Test
     public void registerSuccess() {
+        // Assert if a register was successful and the user was saved properly.
 
+        URegisterRequestModel requestModel = new URegisterRequestModel("John", "Doe",
+                "email@email.com", "password", "password");
         URegisterDsGateway userDsGateway = new URegisterDsGateway() {
             /* Initializing a URegisterDsGateway that states that a user does not exist in the db
             and that the user info was saved.
@@ -55,6 +58,8 @@ public class UserRegisterInteractorTest {
 
             @Override
             public URegisterResponseModel prepareFailView(String error) {
+                // In case of failure
+                fail("Use case failure is unexpected.");
                 return null;
             }
         };
@@ -64,14 +69,14 @@ public class UserRegisterInteractorTest {
         UserRegisterInteractor interactor = new UserRegisterInteractor(userDsGateway,
                 userOutputBoundary, userFactory);
 
-        URegisterRequestModel requestModel = new URegisterRequestModel("John", "Doe",
-                "email@email.com", "password", "password");
-
         interactor.registerUser(requestModel);
     }
     @Test
     public void userExists(){
         // Asserting if the register was a fail because the user exists.
+
+        URegisterRequestModel requestModel = new URegisterRequestModel("John", "Doe",
+                "email@email.com", "password", "password");
         URegisterDsGateway userDsGateway = new URegisterDsGateway() {
             @Override
             public boolean checkIfUserExistsByEmail(String email) {
@@ -92,6 +97,8 @@ public class UserRegisterInteractorTest {
         URegisterOutputBoundary userOutputBoundary = new URegisterOutputBoundary() {
             @Override
             public URegisterResponseModel prepareSuccessView(URegisterResponseModel user) {
+                // In case of failure
+                fail("Use case failure is unexpected.");
                 return null;
             }
 
@@ -107,8 +114,51 @@ public class UserRegisterInteractorTest {
         UserRegisterInteractor interactor = new UserRegisterInteractor(userDsGateway,
                 userOutputBoundary, userFactory);
 
+        interactor.registerUser(requestModel);
+    }
+
+    @Test
+    public void passwordsDontMatch(){
+        // Asserting if the register was a fail because passwords dont match
+
         URegisterRequestModel requestModel = new URegisterRequestModel("John", "Doe",
-                "email@email.com", "password", "password");
+                "email@email.com", "password", "notpassword");
+        URegisterDsGateway userDsGateway = new URegisterDsGateway() {
+            @Override
+            public boolean checkIfUserExistsByEmail(String email) {
+                return false;
+            }
+
+            @Override
+            public boolean saveNewUserInfo(URegisterDsRequestModel requestModel) {
+                return false;
+            }
+
+            @Override
+            public boolean checkIfUserExists(String userId) {
+                return false;
+            }
+        };
+
+        URegisterOutputBoundary userOutputBoundary = new URegisterOutputBoundary() {
+            @Override
+            public URegisterResponseModel prepareSuccessView(URegisterResponseModel user) {
+                // In case of failure
+                fail("Use case failure is unexpected.");
+                return null;
+            }
+
+            @Override
+            public URegisterResponseModel prepareFailView(String error) {
+                assertNotEquals(requestModel.getPassword(), requestModel.getRepeatPassword());
+                return null;
+            }
+        };
+
+        UserFactory userFactory = new UserFactory();
+
+        UserRegisterInteractor interactor = new UserRegisterInteractor(userDsGateway,
+                userOutputBoundary, userFactory);
 
         interactor.registerUser(requestModel);
     }


### PR DESCRIPTION
Creation of two tests for the User Register Use case.

First Test tests if a user entity is created with the same information given by the request model as well as if it receives an 8 digit userID.

Second test tests if it is able to detect if a user already exists with the same email. 

Along with these changes, a getter method was added to the Register Response Model to return the user entity of the response for testing purposes. 

Please let me know if there should be more documentation written for the tests!

Note that these tests currently do not pass due to an issue with the PostGresAccessManager and the CommonUser entity which will be addressed in future PRs.