### PR TITLE
Use Case: Log out user

### DIFF
--- a/src/main/java/uc/user/logout/LogoutInputBoundary.java
+++ b/src/main/java/uc/user/logout/LogoutInputBoundary.java
@@ -1,0 +1,9 @@
+package uc.user.logout;
+
+/**
+ * Defines a logout method to be called by the Controller and implemented by the Use Case Interactor.
+ * @layer use cases
+ */
+public interface LogoutInputBoundary {
+    void logOut ();
+}

--- a/src/main/java/uc/user/logout/LogoutInteractor.java
+++ b/src/main/java/uc/user/logout/LogoutInteractor.java
@@ -1,0 +1,28 @@
+package uc.user.logout;
+
+import entities.StateTracker;
+
+/**
+ * LogoutInteractor implements logout behaviour by removing currentUser
+ * from the state tracker instance, and changing the view to a login screen
+ * @layer use cases
+ */
+
+public class LogoutInteractor implements LogoutInputBoundary {
+    private LogoutOutputBoundary presenter;
+    private StateTracker stateTracker;
+
+    public LogoutInteractor(LogoutOutputBoundary presenter, StateTracker stateTracker) {
+        this.presenter = presenter;
+        this.stateTracker = stateTracker;
+    }
+
+    /**
+     * Remove the currentUser from the stateTracker instance and change the view to a login screen
+     */
+    @Override
+    public void logOut() {
+        stateTracker.removeCurrentUser();
+        presenter.prepareLoginView();
+    }
+}

--- a/src/main/java/uc/user/logout/LogoutInteractor.java
+++ b/src/main/java/uc/user/logout/LogoutInteractor.java
@@ -4,7 +4,7 @@ import entities.StateTracker;
 
 /**
  * LogoutInteractor implements logout behaviour by removing currentUser
- * from the state tracker instance, and changing the view to a login screen
+ * from the state tracker instance, and changing the view to a login screen.
  * @layer use cases
  */
 
@@ -18,7 +18,7 @@ public class LogoutInteractor implements LogoutInputBoundary {
     }
 
     /**
-     * Remove the currentUser from the stateTracker instance and change the view to a login screen
+     * Remove the currentUser from the stateTracker instance and change the view to a login screen.
      */
     @Override
     public void logOut() {

--- a/src/main/java/uc/user/logout/LogoutOutputBoundary.java
+++ b/src/main/java/uc/user/logout/LogoutOutputBoundary.java
@@ -1,7 +1,7 @@
 package uc.user.logout;
 
 /**
- * Defines a method to change the current view to the login screen
+ * Defines a method to change the current view to the login screen.
  * @layer use cases
  */
 public interface LogoutOutputBoundary {

--- a/src/main/java/uc/user/logout/LogoutOutputBoundary.java
+++ b/src/main/java/uc/user/logout/LogoutOutputBoundary.java
@@ -1,0 +1,9 @@
+package uc.user.logout;
+
+/**
+ * Defines a method to change the current view to the login screen
+ * @layer use cases
+ */
+public interface LogoutOutputBoundary {
+    void prepareLoginView ();
+}

--- a/src/main/java/uc/user/logout/package-info.java
+++ b/src/main/java/uc/user/logout/package-info.java
@@ -1,1 +1,4 @@
 package uc.user.logout;
+/**
+ * Contains use case layer classes and interfaces.
+ */

--- a/src/test/java/uc/user/logout/LogoutInteractorTest.java
+++ b/src/test/java/uc/user/logout/LogoutInteractorTest.java
@@ -1,0 +1,36 @@
+package uc.user.logout;
+
+import entities.StateTracker;
+import entities.User;
+import entities.UserFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LogoutInteractorTest {
+    /**
+     * Test that logOut removes currentUser from the state tracker instance
+     */
+    @Test
+    public void logOutRemovesCurrentUser(){
+        LogoutOutputBoundary presenter = new LogoutOutputBoundary() {
+            @Override
+            public void prepareLoginView() {
+            }
+        };
+        StateTracker stateTracker = new StateTracker();
+        UserFactory userFactory = new UserFactory();
+        User user = userFactory.create("First",
+                                       "Last",
+                                       "FirstLast@mail.uoftears.ca",
+                                       "LOL123");
+
+        stateTracker.setCurrentUser(user);
+
+        // run the use case
+        LogoutInteractor interactor = new LogoutInteractor(presenter, stateTracker);
+        interactor.logOut();
+
+        assertNull(stateTracker.getCurrentUser());
+    }
+}


### PR DESCRIPTION
Implemented logOut method which simply removes stateTracker's currentUser and tells the presenter to switch to login view. Wrote a (perhaps redundant) test to check if currentUser is null after calling logOut. Additionally, I omitted input/output data classes and data access gateway. 