### PR TITLE
11 use case 11 vote on solution document upvotedownvote

### DIFF
--- a/src/main/java/fworks/da/PostgresAccessManager.java
+++ b/src/main/java/fworks/da/PostgresAccessManager.java
@@ -672,4 +672,41 @@ public class PostgresAccessManager implements DatabaseAccessGateway {
         }
     }
 
+    /** Queries postgres DB to get the total votes of a solution document.
+     *
+     * @param solutionId             the unique solution Id of the solution document being queried
+     *
+     * @return total votes of solution document
+     */
+    public int getVoteTotalBySolutionIdQuery(String solutionId){
+        int voteTotal = 0;
+        String query = "SELECT vote_total FROM ec.solutions WHERE solution_id='" + solutionId + "';";
+        try (Statement statement = db.createStatement()) {
+            ResultSet rs = statement.executeQuery(query);
+            while (rs.next()) {
+                voteTotal = rs.getInt("vote_total");
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return voteTotal;
+    }
+
+    /** Queries postgres DB to update the total votes of a solution document
+     *
+     * @param solutionId             the unique solution Id of the solution document being queried
+     * @param voteTotal              the total number of votes to update the solution document to
+     *
+     * @return whether the update of total votes was successful
+     */
+    public boolean updateSolutionDocVote(String solutionId, int voteTotal){
+        String query = "UPDATE ec.solutions SET vote_total=" + voteTotal + " WHERE solution_id='" + solutionId + "';";
+        try (Statement statement = db.createStatement()) {
+            statement.executeQuery(query);
+            return true;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 }

--- a/src/main/java/fworks/da/PostgresAccessManager.java
+++ b/src/main/java/fworks/da/PostgresAccessManager.java
@@ -678,6 +678,7 @@ public class PostgresAccessManager implements DatabaseAccessGateway {
      *
      * @return total votes of solution document
      */
+    @Override
     public int getVoteTotalBySolutionIdQuery(String solutionId){
         int voteTotal = 0;
         String query = "SELECT vote_total FROM ec.solutions WHERE solution_id='" + solutionId + "';";
@@ -699,7 +700,8 @@ public class PostgresAccessManager implements DatabaseAccessGateway {
      *
      * @return whether the update of total votes was successful
      */
-    public boolean updateSolutionDocVote(String solutionId, int voteTotal){
+    @Override
+    public boolean updateSolutionDocVoteQuery(String solutionId, int voteTotal){
         String query = "UPDATE ec.solutions SET vote_total=" + voteTotal + " WHERE solution_id='" + solutionId + "';";
         try (Statement statement = db.createStatement()) {
             statement.executeQuery(query);

--- a/src/main/java/ia/controllers/VoteOnDocSolutionController.java
+++ b/src/main/java/ia/controllers/VoteOnDocSolutionController.java
@@ -1,0 +1,20 @@
+package ia.controllers;
+
+import entities.SolutionDocument;
+import uc.doc.voteonsolution.VoteSDocInputBoundary;
+import uc.doc.voteonsolution.VoteSDocRequestModel;
+import uc.doc.voteonsolution.VoteSDocResponseModel;
+
+public class VoteOnDocSolutionController {
+    private final VoteSDocInputBoundary voteSDocInputBoundary;
+
+    public VoteOnDocSolutionController(VoteSDocInputBoundary voteSDocInputBoundary) {
+        this.voteSDocInputBoundary = voteSDocInputBoundary;
+    }
+
+    public VoteSDocResponseModel createInput(String solutionId, String userId, boolean vote, SolutionDocument sDocument){
+        VoteSDocRequestModel voteSDocRequestModel = new VoteSDocRequestModel(solutionId, userId, vote);
+        return voteSDocInputBoundary.voteSolutionDoc(voteSDocRequestModel, sDocument);
+    }
+    
+}

--- a/src/main/java/ia/gateways/DatabaseAccessGateway.java
+++ b/src/main/java/ia/gateways/DatabaseAccessGateway.java
@@ -10,6 +10,8 @@ import uc.doc.submitsolution.SubSDocDsGateway;
 import uc.doc.submitsolution.SubSDocDsRequestModel;
 import uc.doc.submittest.SubTDocDsGateway;
 import uc.doc.submittest.SubTDocDsRequestModel;
+import uc.doc.voteonsolution.VoteSDocDsGateway;
+import uc.doc.voteonsolution.VoteSDocDsRequestModel;
 import uc.state.update.UpdateStateDsGateway;
 import uc.user.login.LoginDsGateway;
 import uc.user.register.URegisterDsGateway;
@@ -48,7 +50,8 @@ public interface DatabaseAccessGateway
         SubSDocDsGateway,
         SubTDocDsGateway,
         LoginDsGateway,
-        URegisterDsGateway {
+        URegisterDsGateway,
+        VoteSDocDsGateway {
 
     // Query methods to be implemented by a concrete database
     // access manager class in Drivers and Frameworks layer.
@@ -146,6 +149,14 @@ public interface DatabaseAccessGateway
      * @return a string representing a unique course ID
      */
     String getCourseIdByTestIdQuery(String testId);
+
+    /** Queries database to get the total votes of a solution document
+     *  corresponding to the given solution ID.
+     *
+     * @param solutionId the solution ID of the solution document being queried
+     * @return an int representing the total votes of the solution document
+     */
+    int getVoteTotalBySolutionIdQuery(String solutionId);
 
     /** Queries database to save data for new solution document entity.
      *
@@ -269,6 +280,16 @@ public interface DatabaseAccessGateway
             String email,
             String hashedPassword
     );
+        
+    /** Queries database to update the total number of votes of the solution document.
+    *
+    * @param solutionId    the solution ID of the solution document to be updated
+    * @param voteTotal        the vote total to update the solution document to
+    */
+   void updateSolutionDocVoteQuery(
+           String solutionId,
+           int voteTotal);
+
 
     // Default methods implementing use case database gateways
     // Note: some methods implement methods across multiple use case gateways
@@ -723,4 +744,19 @@ public interface DatabaseAccessGateway
         }
     }
 
+    /** Updates the total votes for a solution document.
+     *
+     * @param requestModel      the use case DS request model representing the
+     *                          data of the solution document to be updated.
+     *
+     * @return true if update was successful, false otherwise
+     */
+    @Override
+    default boolean updateSolutionDocVote(VoteSDocDsRequestModel requestModel) {
+        updateSolutionDocVoteQuery(
+                requestModel.getSolutionId(),
+                requestModel.getVote()
+        );
+        return true;
+    }
 }

--- a/src/main/java/ia/gateways/DatabaseAccessGateway.java
+++ b/src/main/java/ia/gateways/DatabaseAccessGateway.java
@@ -285,8 +285,10 @@ public interface DatabaseAccessGateway
     *
     * @param solutionId    the solution ID of the solution document to be updated
     * @param voteTotal        the vote total to update the solution document to
+    *
+    * @return true if updating of vote was successful
     */
-   void updateSolutionDocVoteQuery(
+   boolean updateSolutionDocVoteQuery(
            String solutionId,
            int voteTotal);
 
@@ -753,10 +755,9 @@ public interface DatabaseAccessGateway
      */
     @Override
     default boolean updateSolutionDocVote(VoteSDocDsRequestModel requestModel) {
-        updateSolutionDocVoteQuery(
+        return updateSolutionDocVoteQuery(
                 requestModel.getSolutionId(),
                 requestModel.getVote()
         );
-        return true;
     }
 }

--- a/src/main/java/ia/presenters/VoteSDocPresenter.java
+++ b/src/main/java/ia/presenters/VoteSDocPresenter.java
@@ -1,0 +1,5 @@
+package ia.presenters;
+
+public class VoteSDocPresenter {
+    
+}

--- a/src/main/java/ia/presenters/VoteSDocPresenter.java
+++ b/src/main/java/ia/presenters/VoteSDocPresenter.java
@@ -1,5 +1,20 @@
 package ia.presenters;
 
-public class VoteSDocPresenter {
+import uc.doc.voteonsolution.VoteSDocDsRequestModel;
+import uc.doc.voteonsolution.VoteSDocOutputBoundary;
+import uc.doc.voteonsolution.VoteSDocResponseModel;
+
+public class VoteSDocPresenter implements VoteSDocOutputBoundary{
+
+    @Override
+    public VoteSDocResponseModel prepareSuccessView(VoteSDocResponseModel model) {
+        return model;
+    }
+
+    @Override
+    public VoteSDocDsRequestModel prepareFailureView(VoteSDocResponseModel model) {
+        // TODO prepare failure view
+        return null;
+    }
     
 }

--- a/src/main/java/uc/doc/voteonsolution/VoteOnSolutionDocInteractor.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteOnSolutionDocInteractor.java
@@ -1,0 +1,46 @@
+package uc.doc.voteonsolution;
+
+import java.time.LocalDateTime;
+
+import entities.SolutionDocument;
+import entities.StateTracker;
+import entities.User;
+
+public class VoteOnSolutionDocInteractor implements VoteSDocInputBoundary {
+    private final VoteSDocDsGateway voteSDocDsGateway;
+    private final VoteSDocOutputBoundary voteSDocOutputBoundary;
+    private final StateTracker stateTracker;
+ 
+    public VoteOnSolutionDocInteractor(VoteSDocDsGateway voteSDocDsGateway, VoteSDocOutputBoundary voteSDocOutputBoundary, StateTracker stateTracker) {
+        this.voteSDocDsGateway = voteSDocDsGateway;
+        this.voteSDocOutputBoundary = voteSDocOutputBoundary;
+        this.stateTracker = stateTracker;
+    }
+
+    @Override
+    public VoteSDocResponseModel voteSolutionDoc(VoteSDocRequestModel model, SolutionDocument sDocument) {
+        User user = stateTracker.getCurrentUser();
+        boolean vote = model.getVote();
+        String solutionId = model.getSolutionId();
+        int voteTotal = voteSDocDsGateway.getVoteTotalBySolutionIdQuery(solutionId);
+        
+        if (vote){ // Upvote
+            voteTotal += 1;
+        } else { // Downvote
+            voteTotal -= 1;
+        }
+
+        VoteSDocDsRequestModel voteSDocDsRequestModel = new VoteSDocDsRequestModel(solutionId, user.getId(), voteTotal);
+        
+        // Update vote in database
+        voteSDocDsGateway.updateSolutionDocVote(voteSDocDsRequestModel);
+        
+        // Update vote in Solution Document
+        sDocument.setVotes(voteTotal);
+
+        VoteSDocResponseModel voteSDocResponseModel = new VoteSDocResponseModel(voteTotal, sDocument, LocalDateTime.now());
+
+        return voteSDocOutputBoundary.prepareSuccessView(voteSDocResponseModel);
+    }
+    
+}

--- a/src/main/java/uc/doc/voteonsolution/VoteSDocDsGateway.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteSDocDsGateway.java
@@ -1,0 +1,9 @@
+package uc.doc.voteonsolution;
+
+public interface VoteSDocDsGateway {
+
+    int getVoteTotalBySolutionIdQuery(String solutionId);
+
+    boolean updateSolutionDocVote(VoteSDocDsRequestModel model);
+
+}

--- a/src/main/java/uc/doc/voteonsolution/VoteSDocDsRequestModel.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteSDocDsRequestModel.java
@@ -1,0 +1,25 @@
+package uc.doc.voteonsolution;
+
+public class VoteSDocDsRequestModel {
+    private final String solutionId;
+    private final String userId;
+    private final int vote;
+
+    public VoteSDocDsRequestModel(String solutionId, String userId, int vote) {
+        this.solutionId = solutionId;
+        this.userId = userId;
+        this.vote = vote;
+    }
+
+    public String getSolutionId() {
+        return this.solutionId;
+    }
+
+    public String getUserId() {
+        return this.userId;
+    }
+
+    public int getVote() {
+        return this.vote;
+    }
+}

--- a/src/main/java/uc/doc/voteonsolution/VoteSDocInputBoundary.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteSDocInputBoundary.java
@@ -1,0 +1,9 @@
+package uc.doc.voteonsolution;
+
+import entities.SolutionDocument;
+
+public interface VoteSDocInputBoundary {
+    
+    VoteSDocResponseModel voteSolutionDoc(VoteSDocRequestModel model, SolutionDocument sDocument);
+
+}

--- a/src/main/java/uc/doc/voteonsolution/VoteSDocOutputBoundary.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteSDocOutputBoundary.java
@@ -1,0 +1,9 @@
+package uc.doc.voteonsolution;
+
+public interface VoteSDocOutputBoundary {
+
+    VoteSDocResponseModel prepareSuccessView(VoteSDocResponseModel model);
+
+    VoteSDocDsRequestModel prepareFailureView(VoteSDocResponseModel model);
+    
+}

--- a/src/main/java/uc/doc/voteonsolution/VoteSDocRequestModel.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteSDocRequestModel.java
@@ -1,0 +1,25 @@
+package uc.doc.voteonsolution;
+
+public class VoteSDocRequestModel {
+    private final String solutionId;
+    private final String userId;
+    private final boolean vote;
+
+    public VoteSDocRequestModel(String solutionId, String userId, boolean vote) {
+        this.solutionId = solutionId;
+        this.userId = userId;
+        this.vote = vote;
+    }
+
+    public String getSolutionId() {
+        return this.solutionId;
+    }
+
+    public String getUserId() {
+        return this.userId;
+    }
+
+    public boolean getVote() {
+        return this.vote;
+    }
+}

--- a/src/main/java/uc/doc/voteonsolution/VoteSDocResponseModel.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteSDocResponseModel.java
@@ -1,6 +1,5 @@
 package uc.doc.voteonsolution;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 import entities.SolutionDocument;

--- a/src/main/java/uc/doc/voteonsolution/VoteSDocResponseModel.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteSDocResponseModel.java
@@ -1,0 +1,30 @@
+package uc.doc.voteonsolution;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import entities.SolutionDocument;
+
+public class VoteSDocResponseModel {
+    private final int voteTotal;
+    private final SolutionDocument solutionDoc;
+    private final LocalDateTime timestamp;
+
+    public VoteSDocResponseModel(int voteTotal, SolutionDocument solutionDoc, LocalDateTime timestamp) {
+        this.voteTotal = voteTotal;
+        this.solutionDoc = solutionDoc;
+        this.timestamp = timestamp;
+    }
+
+    public int getVoteTotal() {
+        return this.voteTotal;
+    }
+
+    public SolutionDocument getSolutionDoc() {
+        return this.solutionDoc;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return this.timestamp;
+    }
+}


### PR DESCRIPTION
Implemented the following according to CRC model:
`VoteOnDocSolutionController`
`VoteOnSolutionDocInteractor`
`VoteSDocDsGateway`
`VoteSDocDsRequestModel`
`VoteSDocInputBoundary`
`VoteSDocOutputBoundary`
`VoteSDocRequestModel`
`VoteSDocResponseModel`

Implemented `getVoteTotalBySolutionIdQuery` and `updateSolutionDocVote` methods in `DatabaseAccessGateway` and `PostgressAccessManager` to enable upvoting/downvoting of solution documents based on solutionId.

**CLARIFICATION:**
According to the description in the issue, when a user clicks on the thumbs up, a boolean value of `true` will be sent as a parameter into the `voteOnSolutionDoc` method. I assumed that `false` would indicate a downvote. As such, the `vote` parameter in `VoteSDocRequestModel` is a boolean to store `true` or `false` so we can identify if it is an upvote or downvote.

However, I have stored the `vote` parameter in `VoteSDocDsRequestModel` as an `int` as this stores the total number of votes to be updated in the DB. I used the same parameter name to conform with the CRC model but this might be confusing due to the way I've implemented it.