### PR TITLE
fix clean architecture

### DIFF
--- a/src/main/java/ia/controllers/VoteOnDocSolutionController.java
+++ b/src/main/java/ia/controllers/VoteOnDocSolutionController.java
@@ -11,8 +11,8 @@ public class VoteOnDocSolutionController {
         this.voteSDocInputBoundary = voteSDocInputBoundary;
     }
 
-    public VoteSDocResponseModel createInput(String solutionId, String userId, boolean vote){
-        VoteSDocRequestModel voteSDocRequestModel = new VoteSDocRequestModel(solutionId, userId, vote);
+    public VoteSDocResponseModel createInput(String solutionId, boolean vote){
+        VoteSDocRequestModel voteSDocRequestModel = new VoteSDocRequestModel(solutionId, vote);
         return voteSDocInputBoundary.voteSolutionDoc(voteSDocRequestModel);
     }
     

--- a/src/main/java/ia/controllers/VoteOnDocSolutionController.java
+++ b/src/main/java/ia/controllers/VoteOnDocSolutionController.java
@@ -1,6 +1,5 @@
 package ia.controllers;
 
-import entities.SolutionDocument;
 import uc.doc.voteonsolution.VoteSDocInputBoundary;
 import uc.doc.voteonsolution.VoteSDocRequestModel;
 import uc.doc.voteonsolution.VoteSDocResponseModel;
@@ -12,9 +11,9 @@ public class VoteOnDocSolutionController {
         this.voteSDocInputBoundary = voteSDocInputBoundary;
     }
 
-    public VoteSDocResponseModel createInput(String solutionId, String userId, boolean vote, SolutionDocument sDocument){
+    public VoteSDocResponseModel createInput(String solutionId, String userId, boolean vote){
         VoteSDocRequestModel voteSDocRequestModel = new VoteSDocRequestModel(solutionId, userId, vote);
-        return voteSDocInputBoundary.voteSolutionDoc(voteSDocRequestModel, sDocument);
+        return voteSDocInputBoundary.voteSolutionDoc(voteSDocRequestModel);
     }
     
 }

--- a/src/main/java/ia/exceptions/VoteSDocFailed.java
+++ b/src/main/java/ia/exceptions/VoteSDocFailed.java
@@ -1,0 +1,7 @@
+package ia.exceptions;
+
+public class VoteSDocFailed extends RuntimeException{
+    public VoteSDocFailed(String error){
+        super(error);
+    }
+}

--- a/src/main/java/ia/presenters/VoteSDocPresenter.java
+++ b/src/main/java/ia/presenters/VoteSDocPresenter.java
@@ -1,5 +1,6 @@
 package ia.presenters;
 
+import ia.exceptions.VoteSDocFailed;
 import ia.gateways.ViewManagerGateway;
 import uc.doc.voteonsolution.VoteSDocDsRequestModel;
 import uc.doc.voteonsolution.VoteSDocOutputBoundary;
@@ -36,7 +37,7 @@ public class VoteSDocPresenter implements VoteSDocOutputBoundary{
     public VoteSDocDsRequestModel prepareFailureView(String errorMessage) {
         // TODO prepare failure view
         viewManagerGateway.showError(errorMessage, "Document Vote Failed");
-        return null;
+        throw new VoteSDocFailed(errorMessage);
     }
     
 }

--- a/src/main/java/ia/presenters/VoteSDocPresenter.java
+++ b/src/main/java/ia/presenters/VoteSDocPresenter.java
@@ -18,24 +18,24 @@ public class VoteSDocPresenter implements VoteSDocOutputBoundary{
         this.viewManagerGateway = viewManagerGateway;
     }
 
-    /** Prepares SuccessView when a solution document is succesfully voted
+    /** Prepares SuccessView when a solution document is successfully voted
      *
-     * @param model Response model containing the vote total, sDoc and timestamp of the request
-     * @return model Response model corresponding to succesfu
+     * @param model Response model containing the courseId, testId, solutionId and voteTotal
+     * @return model Response model corresponding to successful
      */
     @Override
     public VoteSDocResponseModel prepareSuccessView(VoteSDocResponseModel model) {
         return model;
     }
 
-    /** Prepares SuccessView when a solution document is unsuccesfully voted
+    /** Prepares SuccessView when a solution document is unsuccessfully voted
      *
      * @param errorMessage The errorMessage that occurs when a failure view happens
      * @return
      */
     @Override
     public VoteSDocDsRequestModel prepareFailureView(String errorMessage) {
-        // TODO prepare failure view
+        // TODO: prepare failure view
         viewManagerGateway.showError(errorMessage, "Document Vote Failed");
         throw new VoteSDocFailed(errorMessage);
     }

--- a/src/main/java/uc/doc/voteonsolution/VoteOnSolutionDocInteractor.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteOnSolutionDocInteractor.java
@@ -28,7 +28,7 @@ public class VoteOnSolutionDocInteractor implements VoteSDocInputBoundary {
         this.stateTracker = stateTracker;
     }
 
-    /**Takes in the needed information and updates the vote on a solution document
+    /** Takes in the needed information and updates the vote on a solution document
      * 
      * @param model The vote solution document model containing all the relevant information for updating
      * the vote on a solution document

--- a/src/main/java/uc/doc/voteonsolution/VoteOnSolutionDocInteractor.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteOnSolutionDocInteractor.java
@@ -1,9 +1,9 @@
 package uc.doc.voteonsolution;
 
-import java.time.LocalDateTime;
-
+import entities.Course;
 import entities.SolutionDocument;
 import entities.StateTracker;
+import entities.TestDocument;
 import entities.User;
 
 /** VoteOnSolutionDocInteractor implements the ability to vote on a solution document
@@ -28,8 +28,14 @@ public class VoteOnSolutionDocInteractor implements VoteSDocInputBoundary {
         this.stateTracker = stateTracker;
     }
 
+    /**Takes in the needed information and updates the vote on a solution document
+     * 
+     * @param model The vote solution document model containing all the relevant information for updating
+     * the vote on a solution document
+     * @return If completed, the success view response model, containing information to be presented to the user
+     */
     @Override
-    public VoteSDocResponseModel voteSolutionDoc(VoteSDocRequestModel model, SolutionDocument sDocument) {
+    public VoteSDocResponseModel voteSolutionDoc(VoteSDocRequestModel model) {
         User user = stateTracker.getCurrentUser();
         boolean vote = model.getVote();
         String solutionId = model.getSolutionId();
@@ -43,13 +49,19 @@ public class VoteOnSolutionDocInteractor implements VoteSDocInputBoundary {
 
         VoteSDocDsRequestModel voteSDocDsRequestModel = new VoteSDocDsRequestModel(solutionId, user.getId(), voteTotal);
         
-        // Update vote in database
+        // Update vote in Database
         voteSDocDsGateway.updateSolutionDocVote(voteSDocDsRequestModel);
         
         // Update vote in Solution Document
-        sDocument.setVotes(voteTotal);
+        String testId = voteSDocDsGateway.getTestIdBySolutionId(solutionId);
+        String courseId = voteSDocDsGateway.getCourseIdByTestId(testId);
+        Course course = stateTracker.getCourseIfTracked(courseId);
 
-        VoteSDocResponseModel voteSDocResponseModel = new VoteSDocResponseModel(voteTotal, sDocument, LocalDateTime.now());
+        TestDocument testDoc = course.getTest(testId);
+        SolutionDocument solutionDoc = testDoc.getSolution(solutionId);
+        solutionDoc.setVotes(voteTotal);
+
+        VoteSDocResponseModel voteSDocResponseModel = new VoteSDocResponseModel(courseId, testId, solutionId, voteTotal);
 
         return voteSDocOutputBoundary.prepareSuccessView(voteSDocResponseModel);
     }

--- a/src/main/java/uc/doc/voteonsolution/VoteSDocDsGateway.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteSDocDsGateway.java
@@ -19,4 +19,16 @@ public interface VoteSDocDsGateway {
      */
     boolean updateSolutionDocVote(VoteSDocDsRequestModel model);
 
+    /** Gets the TestId from the database when given the solutionId of the solution the user wants to add a Message to.
+     *
+     * @return returns the String type of the TestId that the solution is written for.
+     */
+    String getTestIdBySolutionId(String solutionId);
+
+    /** Gets the CourseId from the database when given the TestId.
+     *
+     * @return returns the String type of the CourseId that the Test relates to.
+     */
+    String getCourseIdByTestId(String testId);
+    
 }

--- a/src/main/java/uc/doc/voteonsolution/VoteSDocInputBoundary.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteSDocInputBoundary.java
@@ -1,7 +1,5 @@
 package uc.doc.voteonsolution;
 
-import entities.SolutionDocument;
-
 /** VoteSDocInputBoundary provides an entry point from the Interface Adapter layer to the Use Case layer for the
  * vote on solution use case
  * @layer use cases
@@ -11,9 +9,8 @@ public interface VoteSDocInputBoundary {
     /**
      * Invokes the vote on solution use case
      * @param model a request model containing the solutionId, userId, and number of votes
-     * @param sDocument the sDocument being updated
      * @return VoteSDocResponseModel
      */
-    VoteSDocResponseModel voteSolutionDoc(VoteSDocRequestModel model, SolutionDocument sDocument);
+    VoteSDocResponseModel voteSolutionDoc(VoteSDocRequestModel model);
 
 }

--- a/src/main/java/uc/doc/voteonsolution/VoteSDocRequestModel.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteSDocRequestModel.java
@@ -5,18 +5,15 @@ package uc.doc.voteonsolution;
  */
 public class VoteSDocRequestModel {
     private final String solutionId;
-    private final String userId;
     private final boolean vote;
 
     /** Creates an instance of VoteSDocRequestModel containing the ids of the solution and user voting as well as
      * the type of vote.
      * @param solutionId id of the solution being updated
-     * @param userId the id of the user voting
      * @param vote whether it is an upvote or a downvote
      */
-    public VoteSDocRequestModel(String solutionId, String userId, boolean vote) {
+    public VoteSDocRequestModel(String solutionId, boolean vote) {
         this.solutionId = solutionId;
-        this.userId = userId;
         this.vote = vote;
     }
 
@@ -26,14 +23,6 @@ public class VoteSDocRequestModel {
      */
     public String getSolutionId() {
         return this.solutionId;
-    }
-
-    /** Get the userID of the user voting
-     *
-     * @return a string containing the userId
-     */
-    public String getUserId() {
-        return this.userId;
     }
 
     /** Get whether the solution is being up-voted or down-voted

--- a/src/main/java/uc/doc/voteonsolution/VoteSDocResponseModel.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteSDocResponseModel.java
@@ -1,28 +1,43 @@
 package uc.doc.voteonsolution;
 
-import java.time.LocalDateTime;
-
-import entities.SolutionDocument;
-
 /** VoteSDocResponseModel is a bundle of data that can be used by a presenter
  * @layer use cases
  */
 public class VoteSDocResponseModel {
+    private final String courseId;
+    private final String testId;
+    private final String solutionId;
     private final int voteTotal;
-    private final SolutionDocument solutionDoc;
-    private final LocalDateTime timestamp;
 
     /** Create an instance of VoteSDocResponseModel that contains the total number of votes, the solutionDoc
      * and the timestamp of the request
      *
+     * @param courseId Id of the course which the solution belongs to
+     * @param testId Id of the test the solution belongs to
+     * @param solutionId Id of the solution being voted on
      * @param voteTotal total number of votes on the sDoc
-     * @param solutionDoc the solutionDoc being updated
-     * @param timestamp the timestamp of the vote solution request
      */
-    public VoteSDocResponseModel(int voteTotal, SolutionDocument solutionDoc, LocalDateTime timestamp) {
+    public VoteSDocResponseModel(String courseId, String testId, String solutionId, int voteTotal) {
+        this.courseId = courseId;
+        this.testId = testId;
+        this.solutionId = solutionId;
         this.voteTotal = voteTotal;
-        this.solutionDoc = solutionDoc;
-        this.timestamp = timestamp;
+    }
+    
+    /** Gets the Id of the course which the solution belongs to
+     *
+     * @return the Id of the course
+     */
+    public String getCourseId() {
+        return this.courseId;
+    }
+
+    /** Gets the Id of the test which the solution belongs to
+     *
+     * @return the Id of the test
+     */
+    public String getTestId() {
+        return this.testId;
     }
 
     /** Gets the total number of votes that a solution has
@@ -33,19 +48,12 @@ public class VoteSDocResponseModel {
         return this.voteTotal;
     }
 
-    /** Gets the sDoc that is being updated
+    /** Gets the solutionId of the solution that is being updated
      *
-     * @return the sDoc entity that is being voted on
+     * @return the solutionId of the solution that is being voted on
      */
-    public SolutionDocument getSolutionDoc() {
-        return this.solutionDoc;
+    public String getSolutionId() {
+        return this.solutionId;
     }
 
-    /** Get the timestamp of the request
-     *
-     * @return a time corresponding to the timestamp of the request
-     */
-    public LocalDateTime getTimestamp() {
-        return this.timestamp;
-    }
 }


### PR DESCRIPTION
Removed solution document entity from controller, interactor and response model. Replaced the entity in the interactor by retrieving it from helper methods within the stateTracker.

Response model now returns:
`courseId`
`testId`
`solutionId`
`voteTotal`