### PR TITLE
125 error handling for ftp server

### DIFF
--- a/src/main/java/ia/gateways/FileAccessGateway.java
+++ b/src/main/java/ia/gateways/FileAccessGateway.java
@@ -27,5 +27,7 @@ public interface FileAccessGateway extends SubmitSDocFileAccessGateway, SubmitTD
         String documentId = model.getDocumentId();
         return downloadFile(documentId);
     }
+    
+    boolean checkConnectionStatus();
 
 }

--- a/src/main/java/ia/presenters/DownloadDocPresenter.java
+++ b/src/main/java/ia/presenters/DownloadDocPresenter.java
@@ -34,7 +34,7 @@ public class DownloadDocPresenter implements DownloadDocOutputBoundary{
      * @throws DownloadDocFailed when the download doc use case fails.
      */
     @Override
-    public DownloadDocRequestModel prepareFailureView(String errorMessage) {
+    public DownloadDocResponseModel prepareFailureView(String errorMessage) {
         // TODO: prepare failure view
         viewManagerGateway.showError(errorMessage, "Document Download Failed");
         throw new DownloadDocFailed(errorMessage);

--- a/src/main/java/ia/presenters/DownloadDocPresenter.java
+++ b/src/main/java/ia/presenters/DownloadDocPresenter.java
@@ -3,7 +3,6 @@ package ia.presenters;
 import ia.exceptions.DownloadDocFailed;
 import ia.gateways.ViewManagerGateway;
 import uc.doc.downloaddoc.DownloadDocOutputBoundary;
-import uc.doc.downloaddoc.DownloadDocRequestModel;
 import uc.doc.downloaddoc.DownloadDocResponseModel;
 
 public class DownloadDocPresenter implements DownloadDocOutputBoundary{

--- a/src/main/java/ia/presenters/VoteSDocPresenter.java
+++ b/src/main/java/ia/presenters/VoteSDocPresenter.java
@@ -34,7 +34,7 @@ public class VoteSDocPresenter implements VoteSDocOutputBoundary{
      * @return
      */
     @Override
-    public VoteSDocDsRequestModel prepareFailureView(String errorMessage) {
+    public VoteSDocResponseModel prepareFailureView(String errorMessage) {
         // TODO: prepare failure view
         viewManagerGateway.showError(errorMessage, "Document Vote Failed");
         throw new VoteSDocFailed(errorMessage);

--- a/src/main/java/ia/presenters/VoteSDocPresenter.java
+++ b/src/main/java/ia/presenters/VoteSDocPresenter.java
@@ -2,7 +2,6 @@ package ia.presenters;
 
 import ia.exceptions.VoteSDocFailed;
 import ia.gateways.ViewManagerGateway;
-import uc.doc.voteonsolution.VoteSDocDsRequestModel;
 import uc.doc.voteonsolution.VoteSDocOutputBoundary;
 import uc.doc.voteonsolution.VoteSDocResponseModel;
 

--- a/src/main/java/uc/doc/downloaddoc/DownloadDocFileAccessGateway.java
+++ b/src/main/java/uc/doc/downloaddoc/DownloadDocFileAccessGateway.java
@@ -11,4 +11,9 @@ public interface DownloadDocFileAccessGateway {
      */
     String downloadDoc(DownloadDocFileAccessRequestModel downloadDocFileAccessRequestModel);
 
+    /** Check connection status to FTP server
+     * 
+     * @return true if connection is successful, false otherwise
+     */
+    boolean checkConnectionStatus();
 }

--- a/src/main/java/uc/doc/downloaddoc/DownloadDocInteractor.java
+++ b/src/main/java/uc/doc/downloaddoc/DownloadDocInteractor.java
@@ -1,7 +1,5 @@
 package uc.doc.downloaddoc;
 
-import java.time.LocalDateTime;
-
 import entities.StateTracker;
 import entities.User;
 
@@ -36,6 +34,11 @@ public class DownloadDocInteractor implements DownloadDocInputBoundary {
      */
     @Override
     public DownloadDocResponseModel downloadDoc(DownloadDocRequestModel model) {
+        
+        if (!downloadDocFileAccessGateway.checkConnectionStatus()) {
+            return downloadDocOutputBoundary.prepareFailureView("Error connecting to the FTP server");
+        }
+        
         User user = stateTracker.getCurrentUser();
         String documentId = model.getDocumentId();
         String downloadPath;

--- a/src/main/java/uc/doc/downloaddoc/DownloadDocOutputBoundary.java
+++ b/src/main/java/uc/doc/downloaddoc/DownloadDocOutputBoundary.java
@@ -13,6 +13,6 @@ public interface DownloadDocOutputBoundary {
     /** Prepares a failure view
      * @param errorMessage The errorMessage that occurs when a failure view happens
      */
-    DownloadDocRequestModel prepareFailureView(String errorMessage);
+    DownloadDocResponseModel prepareFailureView(String errorMessage);
     
 }

--- a/src/main/java/uc/doc/submitsolution/SubmitSDocFileAccessGateway.java
+++ b/src/main/java/uc/doc/submitsolution/SubmitSDocFileAccessGateway.java
@@ -14,4 +14,9 @@ public interface SubmitSDocFileAccessGateway {
      */
     boolean uploadSolutionDocument(SubmitSDocDsRequestModel model, String docId);
 
+    /** Check connection status to FTP server
+     * 
+     * @return true if connection is successful, false otherwise
+     */
+    boolean checkConnectionStatus();
 }

--- a/src/main/java/uc/doc/submitsolution/SubmitSolutionDocInteractor.java
+++ b/src/main/java/uc/doc/submitsolution/SubmitSolutionDocInteractor.java
@@ -76,6 +76,10 @@ public class SubmitSolutionDocInteractor implements SubmitSDocInputBoundary {
                 solutionId,
                 rootMessageId);
 
+        if (!sDocFileAccessGateway.checkConnectionStatus()) {
+                return sDocOutputBoundary.prepareFailureView("Error connecting to the FTP server");
+        }
+
         sDocFileAccessGateway.uploadSolutionDocument(dsRequestModel, solutionId);
 
         SolutionDocument document = solutionDocFactory.create(

--- a/src/main/java/uc/doc/submittest/SubmitTDocFileAccessGateway.java
+++ b/src/main/java/uc/doc/submittest/SubmitTDocFileAccessGateway.java
@@ -14,4 +14,9 @@ public interface SubmitTDocFileAccessGateway {
      */
     boolean uploadTestDocument(SubmitTDocDsRequestModel dsRequestModel, String docId);
     
+    /** Check connection status to FTP server
+     * 
+     * @return true if connection is successful, false otherwise
+     */
+    boolean checkConnectionStatus();
 }

--- a/src/main/java/uc/doc/submittest/SubmitTestDocInteractor.java
+++ b/src/main/java/uc/doc/submittest/SubmitTestDocInteractor.java
@@ -65,6 +65,10 @@ public class SubmitTestDocInteractor implements SubmitTDocInputBoundary {
 
         String docId = tDocDsGateway.saveTestDocument(dsRequestModel);
         
+        if (!tDocFileAccessGateway.checkConnectionStatus()) {
+            return tDocOutputBoundary.prepareFailureView("Error connecting to the FTP server");
+        }
+        
         tDocFileAccessGateway.uploadTestDocument(dsRequestModel, docId);
 
         TestDocument document = testDocFactory.create(

--- a/src/main/java/uc/doc/voteonsolution/VoteSDocOutputBoundary.java
+++ b/src/main/java/uc/doc/voteonsolution/VoteSDocOutputBoundary.java
@@ -15,6 +15,6 @@ public interface VoteSDocOutputBoundary {
      * Prepares a failure view
      * @param errorMessage The errorMessage that occurs when a failure view happens
      */
-    VoteSDocDsRequestModel prepareFailureView(String errorMessage);
+    VoteSDocResponseModel prepareFailureView(String errorMessage);
     
 }

--- a/src/test/java/uc/doc/voteonsolution/VoteOnSolutionDocInteractorTest.java
+++ b/src/test/java/uc/doc/voteonsolution/VoteOnSolutionDocInteractorTest.java
@@ -83,7 +83,7 @@ public class VoteOnSolutionDocInteractorTest {
             }
 
             @Override
-            public VoteSDocDsRequestModel prepareFailureView(String errorMessage) {
+            public VoteSDocResponseModel prepareFailureView(String errorMessage) {
                 fail("Use case failure is unexpected.");
                 return null;
             }
@@ -138,7 +138,7 @@ public class VoteOnSolutionDocInteractorTest {
             }
 
             @Override
-            public VoteSDocDsRequestModel prepareFailureView(String errorMessage) {
+            public VoteSDocResponseModel prepareFailureView(String errorMessage) {
                 fail("Use case failure is unexpected.");
                 return null;
             }


### PR DESCRIPTION
- Removed connection to FTP server from constructor and added it into a separate `connectFtpServer()` method
- Added `disconnectFtpServer()` method for disconnecting from FTP server
- Added `checkConnectionStatus()` method to check the connection to FTP server and return a boolean
- Implemented this check into use cases that involve the FTP server which returns a failed view to the presenter when connections are unsuccessful